### PR TITLE
[macOS] Fix to show battery percentage for Sierra

### DIFF
--- a/macOS/defaults.sh
+++ b/macOS/defaults.sh
@@ -10,7 +10,7 @@ sudo scutil --set LocalHostName "muffintosh"
 defaults write com.apple.sound.beep.feedback -bool false
 
 # Show battery percentage
-defaults write com.apple.menuextra.battery -bool true
+defaults write com.apple.menuextra.battery ShowPercent -bool true
 
 # Disable the "Are you sure oyu want to open this application?" dialog
 defaults write com.apple.LaunchServices LSQuarantine -bool false


### PR DESCRIPTION
The previous command did not work on my computer running latest Sierra. I found the updated command at [1] and it seems to be working.

[1] https://www.jamf.com/jamf-nation/discussions/20794/enabling-show-battery-percentage-via-script-or-policy